### PR TITLE
Updated IKEPolicy and IPSecPolicy

### DIFF
--- a/ibm/service/power/resource_ibm_pi_ike_policy.go
+++ b/ibm/service/power/resource_ibm_pi_ike_policy.go
@@ -58,7 +58,7 @@ func ResourceIBMPIIKEPolicy() *schema.Resource {
 			helpers.PIVPNPolicyEncryption: {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"3des-cbc", "aes-128-cbc", "aes-128-gcm", "aes-192-cbc", "aes-256-cbc", "aes-256-gcm", "des-cbc"}),
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{"aes-256-cbc", "aes-192-cbc", "aes-128-cbc", "aes-256-gcm", "aes-128-gcm", "3des-cbc"}),
 				Description:  "Encryption of the IKE Policy",
 			},
 			helpers.PIVPNPolicyKeyLifetime: {
@@ -84,7 +84,7 @@ func ResourceIBMPIIKEPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "none",
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"none", "sha-256", "sha-384", "sha1"}),
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{"sha-256", "sha-384", "sha1", "none"}),
 				Description:  "Authentication for the IKE Policy",
 			},
 

--- a/ibm/service/power/resource_ibm_pi_ipsec_policy.go
+++ b/ibm/service/power/resource_ibm_pi_ipsec_policy.go
@@ -54,7 +54,7 @@ func ResourceIBMPIIPSecPolicy() *schema.Resource {
 			helpers.PIVPNPolicyEncryption: {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"3des-cbc", "aes-128-cbc", "aes-128-gcm", "aes-192-cbc", "aes-256-cbc", "aes-256-gcm", "des-cbc"}),
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{"aes-256-cbc", "aes-192-cbc", "aes-128-cbc", "aes-256-gcm", "aes-128-gcm", "3des-cbc"}),
 				Description:  "Encryption of the IPSec Policy",
 			},
 			helpers.PIVPNPolicyKeyLifetime: {
@@ -74,7 +74,7 @@ func ResourceIBMPIIPSecPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "none",
-				ValidateFunc: validate.ValidateAllowedStringValues([]string{"hmac-md5-96", "hmac-sha-256-128", "hmac-sha1-96", "none"}),
+				ValidateFunc: validate.ValidateAllowedStringValues([]string{"hmac-sha-256-128", "hmac-sha1-96", "none"}),
 				Description:  "Authentication for the IPSec Policy",
 			},
 

--- a/ibm/service/power/resource_ibm_pi_ipsec_policy_test.go
+++ b/ibm/service/power/resource_ibm_pi_ipsec_policy_test.go
@@ -33,7 +33,7 @@ func TestAccIBMPIIPSecPolicyBasic(t *testing.T) {
 					testAccCheckIBMPIIPSecPolicyExists(policyRes),
 					resource.TestCheckResourceAttr(policyRes, "pi_policy_name", name),
 					resource.TestCheckResourceAttrSet(policyRes, "policy_id"),
-					resource.TestCheckResourceAttr(policyRes, "pi_policy_authentication", "hmac-md5-96"),
+					resource.TestCheckResourceAttr(policyRes, "pi_policy_authentication", "hmac-sha1-96"),
 				),
 			},
 		},
@@ -98,7 +98,7 @@ func testAccCheckIBMPIIPSecPolicyConfig(name string) string {
 		pi_policy_encryption = "3des-cbc"
 		pi_policy_key_lifetime = 180
 		pi_policy_pfs = true
-		pi_policy_authentication = "hmac-md5-96"
+		pi_policy_authentication = "hmac-sha1-96"
 	}
 	`, acc.Pi_cloud_instance_id, name)
 }

--- a/website/docs/r/pi_vpn_ike_policy.html.markdown
+++ b/website/docs/r/pi_vpn_ike_policy.html.markdown
@@ -18,8 +18,8 @@ The following example creates a IKE Policy.
 		pi_cloud_instance_id    = "<value of the cloud_instance_id>"
 		pi_policy_name          = "test"
 		pi_policy_dh_group = 1
-		pi_policy_encryption = "3des-cbc"
-		pi_policy_key_lifetime = 180
+		pi_policy_encryption = "aes-256-cbc"
+		pi_policy_key_lifetime = 28800
 		pi_policy_preshared_key = "sample"
 		pi_policy_version = 1
 		pi_policy_authentication = "sha1"
@@ -52,9 +52,9 @@ ibm_pi_ike_policy provides the following [timeouts](https://www.terraform.io/doc
 ## Argument reference 
 Review the argument references that you can specify for your resource. 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_policy_authentication`  - (Optional, String) Authentication for the IKE Policy. Supported values are `none`(Default), `sha-256`, `sha-384`, and `sha1`.
+- `pi_policy_authentication`  - (Optional, String) Authentication for the IKE Policy. Supported values are `none`(Default), `sha-256`, `sha-384`, `sha1`.
 - `pi_policy_dh_group` - (Required, Integer) DH group of the IKE Policy. Supported values are `1`,`2`,`5`,`14`,`19`,`20`,`24`.
-- `pi_policy_encryption`- (Required, String) Encryption of the IKE Policy. Supported values are `3des-cbc`,`aes-128-cbc`,`aes-128-gcm`,`aes-192-cbc`,`aes-256-cbc`,`aes-256-gcm`,`des-cbc`.
+- `pi_policy_encryption`- (Required, String) Encryption of the IKE Policy. Supported values are `aes-256-cbc`, `aes-192-cbc`, `aes-128-cbc`, `aes-256-gcm`, `aes-128-gcm`, `3des-cbc`.
 - `pi_policy_key_lifetime` - (Required, Integer) Policy key lifetime. Supported values:  `180` ≤ value ≤ `86400`.
 - `pi_policy_name` - (Required, String) Name of the IKE Policy.
 - `pi_policy_preshared_key` - (Required, String) Preshared key used in this IKE Policy (length of preshared key must be even).

--- a/website/docs/r/pi_vpn_ipsec_policy.html.markdown
+++ b/website/docs/r/pi_vpn_ipsec_policy.html.markdown
@@ -18,10 +18,10 @@ The following example creates a IPSec Policy.
 		pi_cloud_instance_id    = "<value of the cloud_instance_id>"
 		pi_policy_name          = "test"
 		pi_policy_dh_group = 1
-		pi_policy_encryption = "3des-cbc"
-		pi_policy_key_lifetime = 180
+		pi_policy_encryption = "aes-256-cbc"
+		pi_policy_key_lifetime = 28800
 		pi_policy_pfs = true
-		pi_policy_authentication = "hmac-md5-96"
+		pi_policy_authentication = "hmac-sha-256-128"
 	}
 ```
 
@@ -51,9 +51,9 @@ ibm_pi_ipsec_policy provides the following [timeouts](https://www.terraform.io/d
 ## Argument reference 
 Review the argument references that you can specify for your resource. 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_policy_authentication`  - (Optional, String) Authentication for the IPSec Policy. Supported values are `none`(Default), `sha-256`, `sha-384`, and `sha1`.
+- `pi_policy_authentication`  - (Optional, String) Authentication for the IPSec Policy. Supported values are `none`(Default), `hmac-sha-256-128`, `hmac-sha1-96`.
 - `pi_policy_dh_group` - (Required, Integer) DH group of the IPSec Policy. Supported values are `1`,`2`,`5`,`14`,`19`,`20`,`24`.
-- `pi_policy_encryption`- (Required, String) Encryption of the IPSec Policy. Supported values are `3des-cbc`,`aes-128-cbc`,`aes-128-gcm`,`aes-192-cbc`,`aes-256-cbc`,`aes-256-gcm`,`des-cbc`.
+- `pi_policy_encryption`- (Required, String) Encryption of the IPSec Policy. Supported values are `aes-256-cbc`, `aes-192-cbc`, `aes-128-cbc`, `aes-256-gcm`, `aes-128-gcm`, `3des-cbc`.
 - `pi_policy_key_lifetime` - (Required, Integer) Policy key lifetime. Supported values:  `180` ≤ value ≤ `86400`.
 - `pi_policy_name` - (Required, String) Name of the IPSec Policy.
 - `pi_policy_pfs` - (Required, Boolean) Perfect Forward Secrecy.


### PR DESCRIPTION
 - IKEPolicy
   - Removed des-cbc encryption
   - Updated docs
 - IPSecPolicy
   - Removed des-cbc encryption
   - Removed sha-384, sha-256, and sha1 authentication. Added hmac-sha-256-128 and hmac-sha1-96
   - Updated tests
   - Updated docs

Signed off by: Chase Austin [chase@ibm.com](mailto:chase@ibm.com)
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
Output from acceptance testing:
```
=== RUN   TestAccIBMPIIKEPolicyBasic
--- PASS: TestAccIBMPIIKEPolicyBasic (50.71s)

=== RUN   TestAccIBMPIIPSecPolicyBasic
--- PASS: TestAccIBMPIIPSecPolicyBasic (30.80s)
```